### PR TITLE
Add main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "angular",
     "filereader"
   ],
+  "main": "./src/filereader.service.js",
   "author": "Matteo Suppo <matteo.suppo@gmail.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Add the main property to package.json so that if you're not using bower, you can install and require the package into your app.