### PR TITLE
Move angular-mocks to devDependencies, and set correct versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,9 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.16",
-    "angular-mocks": "~1.2.16"
+    "angular": ">=1.3.*",
+  },
+  "devDependencies": {
+    "angular-mocks": ">=1.3.*",
   }
 }


### PR DESCRIPTION
Bower install was broken with `EMALFORMED` error